### PR TITLE
fixed PCB if i-block in iso14443-4 handling

### DIFF
--- a/Firmware/Chameleon-Mini/Application/MifareDesfire.c
+++ b/Firmware/Chameleon-Mini/Application/MifareDesfire.c
@@ -1526,8 +1526,11 @@ uint16_t ISO144434ProcessBlock(uint8_t* Buffer, uint16_t ByteCount)
             }
 
             Buffer[0] = ISO14443_PCB_I_BLOCK_STATIC | MyBlockNumber;
+            PrologueLength = 1;
             if (PCB & ISO14443_PCB_HAS_CID_MASK) {
+            	Buffer[0] |= ISO14443_PCB_HAS_CID_MASK;
                 Buffer[1] = Iso144434CardID;
+                PrologueLength += 1;
             }
             ByteCount = MifareDesfireProcess(Buffer + PrologueLength, ByteCount - PrologueLength);
             if (ByteCount == ISO14443A_APP_NO_RESPONSE) {


### PR DESCRIPTION
alternative to #1.
this fixes a wrong handling of the prologue in iso14443-4 frames.
- `PrologueLength` was not correct when CID is not used
- `CID-bit` in PCB of response was not set when CID is used