### PR TITLE
fixed bug with 3DES auth by resetting desfire state

### DIFF
--- a/Firmware/Chameleon-Mini/Application/MifareDesfire.c
+++ b/Firmware/Chameleon-Mini/Application/MifareDesfire.c
@@ -284,6 +284,7 @@ static uint16_t EV0CmdAuthenticate2KTDEA1(uint8_t* Buffer, uint16_t ByteCount)
 static uint16_t EV0CmdAuthenticate2KTDEA2(uint8_t* Buffer, uint16_t ByteCount)
 {
     Desfire2KTDEAKeyType Key;
+    DesfireState = DESFIRE_IDLE;
 
     /* Validate command length */
     if (ByteCount != 1 + 2 * CRYPTO_DES_BLOCK_SIZE) {


### PR DESCRIPTION
After a successful authentication, the application currently remains in DesfireState = DESFIRE_AUTHENTICATE2 and thus the next command yields a Command Aborted status. This behaviour is changed by this commit.