### PR TITLE
Desfire fix wrong 3des dec

### DIFF
--- a/Firmware/Chameleon-Mini/Application/CryptoTDEA.S
+++ b/Firmware/Chameleon-Mini/Application/CryptoTDEA.S
@@ -148,8 +148,8 @@ _Decrypt2KTDEA:
 
     ; Reload Z with the key block pointer
     movw    r30, r16
-    ; Encipher
-    clh
+    ; Decipher
+    seh
     rjmp    _LoadKeyAndRunDEA
 
 ;

--- a/Firmware/Chameleon-Mini/Application/MifareDesfire.c
+++ b/Firmware/Chameleon-Mini/Application/MifareDesfire.c
@@ -1213,7 +1213,7 @@ static uint16_t MifareDesfireProcess(uint8_t* Buffer, uint16_t ByteCount)
         /* Unwrap the PDU from ISO 7816-4 */
         ByteCount = Buffer[4];
         Buffer[0] = Buffer[1];
-        memmove(&Buffer[2], &Buffer[5], ByteCount);
+        memmove(&Buffer[1], &Buffer[5], ByteCount);
         /* Process the command */
         ByteCount = MifareDesfireProcessCommand(Buffer, ByteCount + 1);
         if (ByteCount) {

--- a/Firmware/Chameleon-Mini/Application/MifareDesfire.c
+++ b/Firmware/Chameleon-Mini/Application/MifareDesfire.c
@@ -1213,7 +1213,7 @@ static uint16_t MifareDesfireProcess(uint8_t* Buffer, uint16_t ByteCount)
         /* Unwrap the PDU from ISO 7816-4 */
         ByteCount = Buffer[4];
         Buffer[0] = Buffer[1];
-        memmove(&Buffer[1], &Buffer[5], ByteCount);
+        memmove(&Buffer[2], &Buffer[5], ByteCount);
         /* Process the command */
         ByteCount = MifareDesfireProcessCommand(Buffer, ByteCount + 1);
         if (ByteCount) {


### PR DESCRIPTION
Fixed bug in 2K3DES decryption, which executed Decrypt - Encrypt - Encrypt instead of Decrypt - Encrypt -Decrypt.